### PR TITLE
Update entrypoint.shfunc application(_ application: NSApplication,   …

### DIFF
--- a/ChatBotAPI/entrypoint.sh
+++ b/ChatBotAPI/entrypoint.sh
@@ -1,7 +1,57 @@
 #!/bin/sh
 
 python DjangoAPI/manage.py migrate --no-input
-python DjangoAPI/manage.py collectstatic --no-input
+python DjangoAPI/manage.py collectstatic default	09:22:11.715909-0700	exchangesyncd	Change Item property_blob size: 5322
+
+default	09:22:11.717092-0700	exchangesyncd	pushing items [(
+
+    "<0x83e30e1c0> Added Canceled: DriveUX: Dev-QA sync up  <NSDateComponents: 0x883963590> {\n    TimeZone: America/Denver (MST) offset -25200\n    Era: 1\n    Calendar Year: 2019\n    Month: 7\n    Day: 2\n    Hour: 10\n    Minute: 0\n    Second: 0\n    Nanosecond: 0 <NSDateComponents: 0x8839634b0> {\n    TimeZone: America/Denver (MST) offset -25200\n    Era: 1\n    Calendar Year: 2019\n    Month: 7\n    Day: 2\n    Hour: 11\n    Minute: 0\n    Second: 0\n    Nanosecond: 0 Event Item change 13649 internal (null) item 13210 SyncProtocol-EWS-0E0BFC6C-F845-443A-BAE6-B98336F55515"
+
+)]
+
+error	09:22:11.720241-0700	exchangesyncd	Error getting event with uniqueId F52A93B6-54F9-40B4-8209-35E209D0EE0E/RID=583776000: Error Domain=EKCADErrorDomain Code=1010 "Object not found. It may have been deleted." UserInfo={NSLocalizedDescription=Object not found. It may have been deleted.}
+
+default	09:22:11.725795-0700	exchangesyncd	creating event [<0x83e30e1c0> Added Canceled: DriveUX: Dev-QA sync up  <NSDateComponents: 0x883963590> {
+
+    TimeZone: America/Denver (MST) offset -25200
+
+    Era: 1
+
+    Calendar Year: 2019
+
+    Month: 7
+
+    Day: 2
+
+    Hour: 10
+
+    Minute: 0
+
+    Second: 0
+
+    Nanosecond: 0 <NSDateComponents: 0x8839634b0> {
+
+    TimeZone: America/Denver (MST) offset -25200
+
+    Era: 1
+
+    Calendar Year: 2019
+
+    Month: 7
+
+    Day: 2
+
+    Hour: 11
+
+    Minute: 0
+
+    Second: 0
+
+    Nanosecond: 0 Event Item change 13649 internal (null) item 13210 SyncProtocol-EWS-0E0BFC6C-F845-443A-BAE6-B98336F55515]
+
+error	09:22:11.727365-0700	exchangesyncd	Error getting event with uniqueId F52A93B6-54F9-40B4-8209-35E209D0EE0E/RID=583776000: Error Domain=EKCADErrorDomain Code=1010 "Object not found. It may have been deleted." UserInfo={NSLocalizedDescription=Object not found. It may have been deleted.}
+
+error	09:22:11.730119-0700	exchangesyncd	Tried to set proposed start date on invalid event: <EKEvent rowid=[16952] UUID=[716ADEF7-FE8B-485F-B17E-D44200878936] start-date=[2019-07-02 16:00:00 +0000]>
 # python DjangoAPI/manage.py runserver 0.0.0.0:8000
 # gunicorn DjangoAPI.wsgi:application --bind 0.0.0.0:8000
 gunicorn -w 2 -b 0.0.0.0:8000 --chdir /code/DjangoAPI DjangoAPI.wsgi


### PR DESCRIPTION
…                   continue userActivity: NSUserActivity,                      restorationHandler: @escaping ([NSUserActivityRestoring]) -> Void) -> Bool {     // Get URL components from the incoming user activity.     guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,         let incomingURL = userActivity.webpageURL,         let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {         return false     }       // Check for specific URL components that you need.     guard let path = components.path,     let params = components.queryItems else {         return false     }         print("path = \(path)")       if let albumName = params.first(where: { $0.name == "albumname" } )?.value,         let photoIndex = params.first(where: { $0.name == "index" })?.value {                     print("album = \(albumName)")         print("photoIndex = \(photoIndex)")         return true         } else {         print("Either album name or photo index missing")         return false     } } This example code shows how to handle a universal link in iOS and tvOS:  func application(_ application: UIApplication,                  continue userActivity: NSUserActivity,                  restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {     // Get URL components from the incoming user activity.     guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,         let incomingURL = userActivity.webpageURL,         let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {         return false     }       // Check for specific URL components that you need.     guard let path = components.path,     let params = components.queryItems else {         return false     }         print("path = \(path)")       if let albumName = params.first(where: { $0.name == "albumname" } )?.value,         let photoIndex = params.first(where: { $0.name == "index" })?.value {           print("album = \(albumName)")         print("photoIndex = \(photoIndex)")         return true       } else {         print("Either album name or photo index missing")         return false     } } If your app has opted into Scenes, and your app is not running, the system delivers the universal link to the scene(_:willConnectTo:options:) delegate method after launch, and to scene(_:continue:) when the universal link is tapped while your app is running or suspended in memory.  func scene(_ scene: UIScene, willConnectTo            session: UISceneSession,            options connectionOptions: UIScene.ConnectionOptions) {          // Get URL components from the incoming user activity.     guard let userActivity = connectionOptions.userActivities.first,         userActivity.activityType == NSUserActivityTypeBrowsingWeb,         let incomingURL = userActivity.webpageURL,         let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {         return     }       // Check for specific URL components that you need.     guard let path = components.path,         let params = components.queryItems else {         return     }     print("path = \(path)")       if let albumName = params.first(where: { $0.name == "albumname" })?.value,         let photoIndex = params.first(where: { $0.name == "index" })?.value {                  print("album = \(albumName)")         print("photoIndex = \(photoIndex)")     } else {         print("Either album name or photo index missing")     } } This example code shows how to handle a universal link in watchOS:  func handle(_ userActivity: NSUserActivity) {     // Get URL components from the incoming user activity.     guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,         let incomingURL = userActivity.webpageURL,         let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else { return }       // Check for specific URL components that you need.     guard let path = components.path,     let params = components.queryItems else { return }         print("path = \(path)")       if let albumName = params.first(where: { $0.name == "albumname" } )?.value,         let photoIndex = params.first(where: { $0.name == "index" })?.value {                     print("album = \(albumName)")         print("photoIndex = \(photoIndex)")     } else {         print("Either album name or photo index missing")     } }

r	09:22:11.730119-0700	exchangesyncd	Tried to set proposed start date on invalid event: <EKEvent rowid=[16952] UUID=[716ADEF7-FE8B-485F-B17E-D44200878936] start-date=[2019-07-02 16:00:00 +0000]>https://home.google.com/welcome/

default	09:22:11.717092-0700	exchangesyncd	pushing items [(

    "<0x83e30e1c0> Added Canceled: DriveUX: Dev-QA sync up  <NSDateComponents: 0x883963590> {\n    TimeZone: America/Denver (MST) offset -25200\n    Era: 1\n    Calendar Year: 2019\n    Month: 7\n    Day: 2\n    Hour: 10\n    Minute: 0\n    Second: 0\n    Nanosecond: 0 <NSDateComponents: 0x8839634b0> {\n    TimeZone: America/Denver (MST) offset -25200\n    Era: 1\n    Calendar Year: 2019\n    Month: 7\n    Day: 2\n    Hour: 11\n    Minute: 0\n    Second: 0\n    Nanosecond: 0 Event Item change 13649 internal (null) item 13210 SyncProtocol-EWS-0E0BFC6C-F845-443A-BAE6-B98336F55515"

)]

error	09:22:11.720241-0700	exchangesyncd	Error getting event with uniqueId F52A93B6-54F9-40B4-8209-35E209D0EE0E/RID=583776000: Error Domain=EKCADErrorDomain Code=1010 "Object not found. It may have been deleted." UserInfo={NSLocalizedDescription=Object not found. It may have been deleted.}

default	09:22:11.725795-0700	exchangesyncd	creating event [<0x83e30e1c0> Added Canceled: DriveUX: Dev-QA sync up  <NSDateComponents: 0x883963590> {

    TimeZone: America/Denver (MST) offset -25200